### PR TITLE
Chore/cleanup

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,6 @@
 require "bundler/gem_tasks"
+require 'rspec/core/rake_task'
+
+RSpec::Core::RakeTask.new(:spec)
+
+task :default => :spec

--- a/nyudl-text.gemspec
+++ b/nyudl-text.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.3"
-  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rake", "< 11.0"
   spec.add_development_dependency "rspec", "~> 2.14"
   spec.add_development_dependency "rspec-its"
   spec.add_development_dependency "fakefs"

--- a/nyudl-text.gemspec
+++ b/nyudl-text.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 2.14"
+  spec.add_development_dependency "rspec-its"
   spec.add_development_dependency "fakefs"
   spec.add_development_dependency "simplecov"
   

--- a/spec/nyudl/text/base_spec.rb
+++ b/spec/nyudl/text/base_spec.rb
@@ -75,7 +75,7 @@ describe Nyudl::Text::Base do
       end
       it "returns true if valid and called after #analyze" do
         text.analyze
-        text.valid?.should be_true
+        text.valid?.should be true
       end
     end
 
@@ -83,7 +83,7 @@ describe Nyudl::Text::Base do
       subject(:text) { stub_recognized_text }
       it "returns false if renaming required and called after #analyze" do
         text.analyze
-        text.valid?.should be_false
+        text.valid?.should be false
       end
     end
   end
@@ -196,7 +196,7 @@ describe Nyudl::Text::Base do
       subject (:text) { stub_valid_text }
       it "returns false" do
         text.analyze
-        text.rename?.should be_false
+        text.rename?.should be false
       end
     end
 
@@ -204,7 +204,7 @@ describe Nyudl::Text::Base do
       subject (:text) { stub_recognized_text }
       it "returns true" do
         text.analyze
-        text.rename?.should be_true
+        text.rename?.should be true
       end
     end
 
@@ -212,7 +212,7 @@ describe Nyudl::Text::Base do
       subject (:text) { stub_unrecognized_text }
       it "returns true" do
         text.analyze
-        text.rename?.should be_true
+        text.rename?.should be true
       end
     end
 
@@ -227,13 +227,13 @@ describe Nyudl::Text::Base do
       end
       it "does nothing when called after #analyze" do
         text.analyze
-        text.valid?.should be_true
-        text.rename?.should be_false
+        text.valid?.should be true
+        text.rename?.should be false
         text.errors.should be_empty
         text.rename!
         text.analyze
-        text.valid?.should be_true
-        text.rename?.should be_false
+        text.valid?.should be true
+        text.rename?.should be false
         text.errors.should be_empty
       end
     end
@@ -242,14 +242,14 @@ describe Nyudl::Text::Base do
       subject(:text) { stub_recognized_text }
       it "renames the files" do
         text.analyze
-        text.valid?.should be_false
-        text.rename?.should be_true
+        text.valid?.should be false
+        text.rename?.should be true
         text.errors.should be_empty
         text.rename!
-        text.analyzed?.should be_false
+        text.analyzed?.should be false
         text.analyze
-        text.valid?.should be_true
-        text.rename?.should be_false
+        text.valid?.should be true
+        text.rename?.should be false
         text.errors.should be_empty
       end
     end
@@ -258,8 +258,8 @@ describe Nyudl::Text::Base do
       subject(:text) { stub_unrecognized_text }
       it "raises an exception" do
         text.analyze
-        text.valid?.should be_false
-        text.rename?.should be_true
+        text.valid?.should be false
+        text.rename?.should be true
         text.errors.should_not be_empty
         expect {text.rename!}.to raise_error RuntimeError
       end
@@ -269,8 +269,8 @@ describe Nyudl::Text::Base do
       subject(:text) { stub_collision_text }
       it "raises an exception the files" do
         text.analyze
-        text.valid?.should be_false
-        text.rename?.should be_true
+        text.valid?.should be false
+        text.rename?.should be true
         text.errors.should be_empty
         expect {text.rename!}.to raise_error RuntimeError
       end

--- a/spec/nyudl/text/errors_spec.rb
+++ b/spec/nyudl/text/errors_spec.rb
@@ -94,7 +94,7 @@ describe Nyudl::Text::Errors do
     context "before errors are added" do
       subject(:e) { Nyudl::Text::Errors.new() }
       it "returns true" do
-        e.empty?.should be_true
+        e.empty?.should be true
       end
     end
 
@@ -107,7 +107,7 @@ describe Nyudl::Text::Errors do
       }
 
       it "returns false" do
-        e.empty?.should be_false
+        e.empty?.should be false
       end
     end
   end

--- a/spec/nyudl/text/state_machine_spec.rb
+++ b/spec/nyudl/text/state_machine_spec.rb
@@ -9,12 +9,12 @@ describe Text::StateMachine do
     end
 
     it "accepts transition to fm" do
-      sm.found_fm.should be_true
+      sm.found_fm.should be true
       sm.should be_fm
     end
 
     it "accepts transition to np" do
-      sm.found_np.should be_true
+      sm.found_np.should be true
       sm.should be_np
     end
 
@@ -23,12 +23,12 @@ describe Text::StateMachine do
     end
 
     it "accepts transition to in" do
-      sm.found_in.should be_true
+      sm.found_in.should be true
       sm.should be_in
     end
 
     it "accepts transition to ov" do
-      sm.found_ov.should be_true
+      sm.found_ov.should be true
       sm.should be_ov
     end
 
@@ -45,32 +45,32 @@ describe Text::StateMachine do
     end
 
     it "accepts transition to fm" do
-      sm.found_fm.should be_true
+      sm.found_fm.should be true
       sm.should be_fm
     end
 
     it "accepts transition to np" do
-      sm.found_np.should be_true
+      sm.found_np.should be true
       sm.should be_np
     end
 
     it "accepts transition to bm" do
-      sm.found_bm.should be_true
+      sm.found_bm.should be true
       sm.should be_bm
     end
 
     it "accepts transition to in" do
-      sm.found_in.should be_true
+      sm.found_in.should be true
       sm.should be_in
     end
 
     it "accepts transition to ov" do
-      sm.found_ov.should be_true
+      sm.found_ov.should be true
       sm.should be_ov
     end
 
     it "accepts transition to end" do
-      sm.found_end.should be_true
+      sm.found_end.should be true
       sm.should be_end
     end
   end
@@ -87,27 +87,27 @@ describe Text::StateMachine do
     end
 
     it "accepts transition to np" do
-      sm.found_np.should be_true
+      sm.found_np.should be true
       sm.should be_np
     end
 
     it "accepts transition to bm" do
-      sm.found_bm.should be_true
+      sm.found_bm.should be true
       sm.should be_bm
     end
 
     it "accepts transition to in" do
-      sm.found_in.should be_true
+      sm.found_in.should be true
       sm.should be_in
     end
 
     it "accepts transition to ov" do
-      sm.found_ov.should be_true
+      sm.found_ov.should be true
       sm.should be_ov
     end
 
     it "accepts transition to end" do
-      sm.found_end.should be_true
+      sm.found_end.should be true
       sm.should be_end
     end
   end
@@ -128,22 +128,22 @@ describe Text::StateMachine do
     end
 
     it "accepts transition to bm" do
-      sm.found_bm.should be_true
+      sm.found_bm.should be true
       sm.should be_bm
     end
 
     it "accepts transition to in" do
-      sm.found_in.should be_true
+      sm.found_in.should be true
       sm.should be_in
     end
 
     it "accepts transition to ov" do
-      sm.found_ov.should be_true
+      sm.found_ov.should be true
       sm.should be_ov
     end
 
     it "accepts transition to end" do
-      sm.found_end.should be_true
+      sm.found_end.should be true
       sm.should be_end
     end
   end
@@ -156,32 +156,32 @@ describe Text::StateMachine do
     end
 
     it "accepts transition to fm" do
-      sm.found_fm.should be_true
+      sm.found_fm.should be true
       sm.should be_fm
     end
 
     it "accepts transition to np" do
-      sm.found_np.should be_true
+      sm.found_np.should be true
       sm.should be_np
     end
 
     it "accepts transition to bm" do
-      sm.found_bm.should be_true
+      sm.found_bm.should be true
       sm.should be_bm
     end
 
     it "accepts transition to in" do
-      sm.found_in.should be_true
+      sm.found_in.should be true
       sm.should be_in
     end
 
     it "accepts transition to ov" do
-      sm.found_ov.should be_true
+      sm.found_ov.should be true
       sm.should be_ov
     end
 
     it "accepts transition to end" do
-      sm.found_end.should be_true
+      sm.found_end.should be true
       sm.should be_end
     end
   end
@@ -194,32 +194,32 @@ describe Text::StateMachine do
     end
 
     it "accepts transition to fm" do
-      sm.found_fm.should be_true
+      sm.found_fm.should be true
       sm.should be_fm
     end
 
     it "accepts transition to np" do
-      sm.found_np.should be_true
+      sm.found_np.should be true
       sm.should be_np
     end
 
     it "accepts transition to bm" do
-      sm.found_bm.should be_true
+      sm.found_bm.should be true
       sm.should be_bm
     end
 
     it "accepts transition to in" do
-      sm.found_in.should be_true
+      sm.found_in.should be true
       sm.should be_in
     end
 
     it "accepts transition to ov" do
-      sm.found_ov.should be_true
+      sm.found_ov.should be true
       sm.should be_ov
     end
 
     it "accepts transition to end" do
-      sm.found_end.should be_true
+      sm.found_end.should be true
       sm.should be_end
     end
   end
@@ -271,17 +271,17 @@ end
   end
 
   it "should initialize in the start state" do
-    expect(sm.start?).to be_true
+    expect(sm.start?).to be true
   end
 
   it "should allow transition from start to front matter" do
-    expect(sm.found_fm).to be_true
-    expect(sm.fm?).to be_true
+    expect(sm.found_fm).to be true
+    expect(sm.fm?).to be true
   end
 
  # it "should throw and exception when transitioning from start to end" do
  #   expect(@sm.found_end).exception.to == 
- #   expect(@sm.end?).to be_true
+ #   expect(@sm.end?).to be true
  # end
 
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ rescue LoadError
   puts 'Coverage disabled, enable by installing simplecov'
 end
 
+require 'rspec/its'
 require 'fakefs/spec_helpers'
 require 'fileutils'
 


### PR DESCRIPTION
## Overview
* tweak specs to remove deprecation warnings
  * add `rspec-its` gem
  * tweak assertions, e.g., change `be_true` to `be true`
* set `rspec` as default `rake` task
